### PR TITLE
feat: 채팅 메시지 상태관리 기능 추가 및 메시지 디자인 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3774,6 +3774,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect, useRef } from 'react';
+// import Slider from './Slider';
+
+const Main = () => {
+
+  /*
+    슬라이더 자동 이간 시간. useRef는 참조(reference)를 의미하며,
+    직접적인 DOM요소 접근, 리렌더링 되도 값 보존. 외부 라이브러리 연동등에 사용된다고 한다.
+    setTimeout은 일정시간 후 callback을 실행해줄 수 있는 js function이다.
+    즉 slideInterval은 값이 없거나,  일정시간 후 callback을 호출하는 값을 참조하고 있다.
+  */
+  const [mainSlides, setMainSlides] = useState<any[]>([]);
+  const [apisSlides, setApisSlides] = useState<any[]>([]);
+  const [kopisSlides, setKopisSlides] = useState<any[]>([]);
+
+  
+  const getSlideData = async () => {
+    try {
+
+      const mainSlideData = await fetch('http://localhost:8090/api/v1/festivalPosts/slideData');
+      const mainData = await mainSlideData.json();
+      setMainSlides(mainData);
+  
+      const categorySlideData = await fetch('http://localhost:8090/api/v1/festivalPosts/getForSlid');
+      const categoryData = await categorySlideData.json();
+
+      setApisSlides(categoryData.APIS);
+      setKopisSlides(categoryData.KOPIS);
+
+    } catch (error) {
+      console.error('슬라이드 데이터를 가져오는 데 실패했습니다:', error);
+    }
+  };
+
+
+  useEffect(() => {
+    getSlideData();
+  }, []);
+
+
+  return (
+    <div className="main-content">
+      {/* <Slider slides={mainSlides} title="" autoSlide={true} />
+      <Slider slides={apisSlides} title="" autoSlide={false} />
+      <Slider slides={kopisSlides} title="" autoSlide={false} /> */}
+    </div>
+  );
+};
+
+export default Main;

--- a/websocket-app/src/components/Chat.tsx
+++ b/websocket-app/src/components/Chat.tsx
@@ -16,9 +16,11 @@ interface PageInfo {
     totalPages: number;
 }
 
-interface ChatResponse {
-    content: ChatMessage[];
-    page: PageInfo;
+interface ChatResponse {    // RsData 형식에 맞춰서 수정
+    data: {
+        content: ChatMessage[];
+        page: PageInfo;
+    }
 }
 
 const WEBSOCKET_URL = 'ws://localhost:8090/ws/chat';
@@ -44,20 +46,20 @@ const Chat: React.FC<{ chatRoomId: number; memberId: number }> = ({ chatRoomId, 
             );
 
             if (page === 0) {
-                setMessages(response.data.content);
+                setMessages(response.data.data.content);
                 // 첫 로드시 가장 최신 메시지의 읽음 상태 업데이트
-                if (response.data.content.length > 0) {
-                    const latestMessage = response.data.content[0]; // 가장 최신 메시지
+                if (response.data.data.content.length > 0) {
+                    const latestMessage = response.data.data.content[0]; // 가장 최신 메시지
                     if (latestMessage.messageId) {  // id 필드 추가 필요
                         updateMessageReadStatus(latestMessage.messageId);
                     }
                 }
                 setTimeout(() => scrollToBottom(), 100);
             } else {
-                setMessages(prev => [...prev, ...response.data.content]);
+                setMessages(prev => [...prev, ...response.data.data.content]);
             }
 
-            setHasMore(page < response.data.page.totalPages - 1);
+            setHasMore(page < response.data.data.page.totalPages - 1);
         } catch (error) {
             console.error('메시지 조회 실패:', error);
         }


### PR DESCRIPTION
## 기능 상세

- 사용자별 메시지 읽음/안읽음 상태를 조회 및 변경할 수 있는 기능 개발.

## 수정사항

- ERD 테이블 구조 변경으로 인해 API 명세 변경

- PUT : /api/v1/chatRooms/{chatRoom-id}/messages/readStatus

- 채팅 수신 확인 테이블을 새로 생성, 멤버 별 마지막으로 확인한 메시지 ID를 컬럼에 저장하여 이를 기준으로 메시지 상태를 처리함